### PR TITLE
fix: github permissions for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Release
         uses: go-semantic-release/action@v1.21
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
           hooks: goreleaser
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
In #132 updated how goreleaser would be called but update to permissions is needed.