### PR TITLE
chore: put team-transportation as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
- * @odsod
+ * @odsod @einride/team-transportation
 
 proto/einride/extend/book @einride/team-book


### PR DESCRIPTION
Team will be taking over ownership of the public API so makes sense to have them as codeowner. I've kept you @odsod in there as well but feel free to remove if you want :) 