### PR TITLE
chore: remove team-book from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
  * @odsod @einride/team-transportation
 
-proto/einride/extend/book @einride/team-book


### PR DESCRIPTION
If approved, this PR will remove codeowner references to obsolete team book
