### PR TITLE
chore: fixup GHA generating api docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
         with:
-          go-version: '^1.20'
+          go-version: '^1.21'
           check-latest: true
           fetch-depth: 1 // only get latest commit
 
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
         with:
-          go-version: '^1.20'
+          go-version: '^1.21'
           check-latest: true
           fetch-depth: 1 // only get latest commit
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
         with:
-          go-version: '^1.20'
+          go-version: '^1.21'
           check-latest: true
           fetch-depth: 1 // only get latest commit
 

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -103,7 +103,10 @@ func GenerateApiDoc(ctx context.Context) error {
 }
 
 func installRapiPdfCli(ctx context.Context) error {
-	cmd := sg.Command(ctx, "yarn", "add", "@kingjan1999/rapipdf-cli")
+	if err := sg.Command(ctx, "yarn", "global", "add", "node-gyp").Run(); err != nil {
+		return err
+	}
+	cmd := sg.Command(ctx, "yarn", "global", "add", "@kingjan1999/rapipdf-cli")
 	return cmd.Run()
 }
 
@@ -151,7 +154,6 @@ func generatePdfFromSwagger(ctx context.Context, name, configPath string) error 
 func generatePdf(ctx context.Context, configPath, outputFilename, openApiFileName string) error {
 	cmd := sg.Command(
 		ctx,
-		"yarn",
 		"rapipdf",
 		"--configFile="+configPath,
 		"--outputFile="+outputFilename,


### PR DESCRIPTION
Saw the following error on master build but couldn't recreate locally: https://github.com/einride/extend/actions/runs/6505741530/job/17671262257
Tested globally installing the tool and generating the docs on branch and this works: https://github.com/einride/extend/actions/runs/6506820756/job/17673114290?pr=200