### PR TITLE
fix(CI): replace yarn1 with npm when generating PDF docs

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -103,10 +103,9 @@ func GenerateApiDoc(ctx context.Context) error {
 }
 
 func installRapiPdfCli(ctx context.Context) error {
-	if err := sg.Command(ctx, "yarn", "global", "add", "node-gyp").Run(); err != nil {
-		return err
-	}
-	cmd := sg.Command(ctx, "yarn", "global", "add", "@kingjan1999/rapipdf-cli")
+	// Using npm rather than yarn as yarn1 struggles with the dependency "string-width"
+	// and breaks the CI. https://github.com/einride/extend/pull/221
+	cmd := sg.Command(ctx, "npm", "--global", "install", "@kingjan1999/rapipdf-cli")
 	return cmd.Run()
 }
 


### PR DESCRIPTION
yarn1 appears to struggle with a dependency "string-width". To prevent CI from breaking, this PR replaces the use of yarn with npm when generating documentation PDF.
Issue reported in multiple places such as:
https://github.com/yarnpkg/yarn/issues/8994
https://github.com/storybookjs/storybook/issues/22431