### PR TITLE
chore: remove go and typescript sdk docs

### DIFF
--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -6,21 +6,3 @@ any of the currently supported programming languages.
 If your preferred language is not yet supported, we recommend to use the
 [protobuf](./proto) or [OpenAPI](./openapiv2) specifications to generate an API
 client for your language.
-
-## Go
-
-The [Saga Go](https://github.com/einride/saga-go) SDK is available as a Go
-module:
-
-```
-go get go.einride.tech/saga
-```
-
-## TypeScript
-
-The [Saga TypeScript](https://github.com/einride/saga-typescript) SDK can be
-used withj both TypeScript and JavaScript, and is available as an NPM package:
-
-```
-npm install @einride/saga
-```


### PR DESCRIPTION
They do not exist.
