### PR TITLE
docs: add note on updating a confirmed Tour

### DIFF
--- a/cmd/saga/gen/einride/saga/extend/book/v1beta1/booking_service_cli.pb.go
+++ b/cmd/saga/gen/einride/saga/extend/book/v1beta1/booking_service_cli.pb.go
@@ -189,7 +189,7 @@ func NewBookingServiceCommand(config aipcli.Config) *cobra.Command {
 				"einride.saga.extend.book.v1beta1.Address.recipient":                               " Recipient\n",
 				"einride.saga.extend.book.v1beta1.Address.region_code":                             " Region code (Unicode CLDR region code)\n https://cldr.unicode.org/\n",
 				"einride.saga.extend.book.v1beta1.Address.state_code":                              " State code\n",
-				"einride.saga.extend.book.v1beta1.BookingService.UpdateTour":                       " Update a tour.\n\n See: https://google.aip.dev/134 (Standard methods: Update).\n",
+				"einride.saga.extend.book.v1beta1.BookingService.UpdateTour":                       " Update a tour.\n\n See: https://google.aip.dev/134 (Standard methods: Update).\n If the tour has been confirmed, only a selection of fields can be updated: Stops.RequestedStartTime, Stops.RequestedEndTime, Annotations, PreliminaryShipments.Annotations.\n",
 				"einride.saga.extend.book.v1beta1.Shipment.AnnotationsEntry.key":                   "",
 				"einride.saga.extend.book.v1beta1.Shipment.AnnotationsEntry.value":                 "",
 				"einride.saga.extend.book.v1beta1.Shipment.annotations":                            " Annotations for the shipment\n",

--- a/cmd/saga/gen/einride/saga/extend/book/v1beta1/booking_service_grpc.pb.go
+++ b/cmd/saga/gen/einride/saga/extend/book/v1beta1/booking_service_grpc.pb.go
@@ -57,6 +57,7 @@ type BookingServiceClient interface {
 	// Update a tour.
 	//
 	// See: https://google.aip.dev/134 (Standard methods: Update).
+	// If the tour has been confirmed, only a selection of fields can be updated: Stops.RequestedStartTime, Stops.RequestedEndTime, Annotations, PreliminaryShipments.Annotations.
 	UpdateTour(ctx context.Context, in *UpdateTourRequest, opts ...grpc.CallOption) (*Tour, error)
 	// Cancel a tour.
 	CancelTour(ctx context.Context, in *CancelTourRequest, opts ...grpc.CallOption) (*Tour, error)
@@ -162,6 +163,7 @@ type BookingServiceServer interface {
 	// Update a tour.
 	//
 	// See: https://google.aip.dev/134 (Standard methods: Update).
+	// If the tour has been confirmed, only a selection of fields can be updated: Stops.RequestedStartTime, Stops.RequestedEndTime, Annotations, PreliminaryShipments.Annotations.
 	UpdateTour(context.Context, *UpdateTourRequest) (*Tour, error)
 	// Cancel a tour.
 	CancelTour(context.Context, *CancelTourRequest) (*Tour, error)

--- a/openapiv2/book.swagger.yaml
+++ b/openapiv2/book.swagger.yaml
@@ -652,7 +652,9 @@ paths:
   /v1beta1/{tour.name}:
     patch:
       summary: Update a tour.
-      description: 'See: https://google.aip.dev/134 (Standard methods: Update).'
+      description: |-
+        See: https://google.aip.dev/134 (Standard methods: Update).
+        If the tour has been confirmed, only a selection of fields can be updated: Stops.RequestedStartTime, Stops.RequestedEndTime, Annotations, PreliminaryShipments.Annotations.
       operationId: BookingService_UpdateTour
       responses:
         "200":

--- a/proto/einride/saga/extend/book/v1beta1/booking_service.proto
+++ b/proto/einride/saga/extend/book/v1beta1/booking_service.proto
@@ -97,6 +97,7 @@ service BookingService {
   // Update a tour.
   //
   // See: https://google.aip.dev/134 (Standard methods: Update).
+  // If the tour has been confirmed, only a selection of fields can be updated: Stops.RequestedStartTime, Stops.RequestedEndTime, Annotations, PreliminaryShipments.Annotations.
   rpc UpdateTour(UpdateTourRequest) returns (Tour) {
     option (google.api.http) = {
       patch: "/v1beta1/{tour.name=spaces/*/tours/*}"

--- a/proto/gen/go/einride/saga/extend/book/v1beta1/booking_service_grpc.pb.go
+++ b/proto/gen/go/einride/saga/extend/book/v1beta1/booking_service_grpc.pb.go
@@ -57,6 +57,7 @@ type BookingServiceClient interface {
 	// Update a tour.
 	//
 	// See: https://google.aip.dev/134 (Standard methods: Update).
+	// If the tour has been confirmed, only a selection of fields can be updated: Stops.RequestedStartTime, Stops.RequestedEndTime, Annotations, PreliminaryShipments.Annotations.
 	UpdateTour(ctx context.Context, in *UpdateTourRequest, opts ...grpc.CallOption) (*Tour, error)
 	// Cancel a tour.
 	CancelTour(ctx context.Context, in *CancelTourRequest, opts ...grpc.CallOption) (*Tour, error)
@@ -162,6 +163,7 @@ type BookingServiceServer interface {
 	// Update a tour.
 	//
 	// See: https://google.aip.dev/134 (Standard methods: Update).
+	// If the tour has been confirmed, only a selection of fields can be updated: Stops.RequestedStartTime, Stops.RequestedEndTime, Annotations, PreliminaryShipments.Annotations.
 	UpdateTour(context.Context, *UpdateTourRequest) (*Tour, error)
 	// Cancel a tour.
 	CancelTour(context.Context, *CancelTourRequest) (*Tour, error)


### PR DESCRIPTION
### Why this change?

We made it possible to edit annotations on a confirmed tour. Makes sense to mention this change in the docs.

### What was changed?

- Add note on which fields can be updated on a confirmed tour.


[TRA-1521]: https://einride.atlassian.net/browse/TRA-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ