### PR TITLE
Fix wrong yaml syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           go-version: '1.23'
           check-latest: true
-          fetch-depth: 1 // only get latest commit
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.4
@@ -52,7 +51,6 @@ jobs:
         with:
           go-version: '1.23'
           check-latest: true
-          fetch-depth: 1 // only get latest commit
 
       - name: Make
         run: make

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           go-version: '1.23'
           check-latest: true
-          fetch-depth: 1 // only get latest commit
 
       - name: Make
         run: make


### PR DESCRIPTION
Comments are written prefixed by `#` symbol in yaml.


```
[convco-check] revspec 'origin/master' not found; class=Reference (4); code=NotFound (-3)
```

