### PR TITLE
fix(buf): remove unwanted rule exceptions

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -10,8 +10,6 @@ lint:
     - STANDARD
   except:
     - ENUM_VALUE_PREFIX
-    - FIELD_NOT_REQUIRED
-    - PACKAGE_NO_IMPORT_CYCLE
     - RPC_REQUEST_RESPONSE_UNIQUE
     - RPC_RESPONSE_STANDARD_NAME
   ignore:
@@ -20,8 +18,5 @@ lint:
 breaking:
   use:
     - PACKAGE
-  except:
-    - FIELD_SAME_DEFAULT
-    - PACKAGE_EXTENSION_NO_DELETE
   ignore:
     - google


### PR DESCRIPTION
The buf migration tool added some exception rules I didn't ask for in #268.
Seems wrong to add these to me unless we explicitly have a need for them.

The `disallow_comment_ignores` is by default set to `false` and allows for
setting ignores by comments. Setting this to `true` prevents such
ignore-comments. I can't find any information on why the migration
tool added this (maybe to keep backwards compat?) so I left that in.
But we can get rid of that too, if we think it will be confusing.
