### PR TITLE
chore: use node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4.0.4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Generate API Documentation
         run: make generate-api-doc
@@ -71,4 +71,3 @@ jobs:
           hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
Since node v22 will become LTS in next week, we can safely recommend v22 for this repo. Setting engine configuration is just a recommendation so updating here for documentation purpose.
https://nodejs.org/en/about/previous-releases