### PR TITLE
ci(dependabot): combine gomod ecosystems into one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,37 +2,20 @@ version: 2
 
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories: ["/"]
     schedule:
       interval: monthly
     groups:
-      github-dependencies:
-        patterns:
-          - "*"  # Include all dependencies in one PR
-        update-types:
-          - "minor"
-          - "patch"
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies"]
 
   - package-ecosystem: gomod
-    directory: cmd/saga
+    directories: [".", "./.sage", "./cmd/saga"]
     schedule:
       interval: monthly
     groups:
-      go-dependencies:
-        patterns:
-          - "*"  # Include all dependencies in one PR
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: gomod
-    directory: .sage
-    schedule:
-      interval: monthly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"  # Include all dependencies in one PR
-        update-types:
-          - "minor"
-          - "patch"
+      gomod-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels: ["dependencies"]


### PR DESCRIPTION
## TRA-2556

### Why?
We can make dependabot create one single PR instead of one per `go.mod` file (usually three; one for git root, one for `backend` and one for `.sage`).

This will help avoid this churn:
1. rebase first PR, potentially run `make`, merge and wait
1. rebase second PR, potentially run `make`, merge and wait
1. rebase third PR, potentially run `make`, merge

Essentially, making it easier to get dependabot PRs merged without all the churn, condensing all of the above into just the first bullet point, hopefully? 🤞

### What?

- Executed a script which re-generates the `dependabot.yml` file from scratch (detects eco-systems in the repo).
- The primary intent is to replace the `directory` field with `directories` field.

### Notes

- ⚠️ Side effects of running the script which regenerated the `dependabot.yml` may involve restructuring the contents of the file and potentially adding/removing eco-systems, so please review carefully!
- I did not keep the exclusion pattern for `google.golang.org/protobuf`, as I don't see why we'd want to keep it. Let me know if you think we should put it back in and I can re-generate the PR(s).
