### PR TITLE
chore: fix dependabot cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,6 @@ updates:
 
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
   - package-ecosystem: gomod
     directories: [".", "./.sage", "./cmd/saga"]
     schedule:


### PR DESCRIPTION
removes semver options for ecosystems that dont support them